### PR TITLE
Add show_only_error flag to `aws s3 sync` command

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -97,6 +97,7 @@ echo_details "* upload_local_path: $upload_local_path"
 echo_details "* acl_control: $acl_control"
 echo_details "* set_acl_only_on_changed_objets: $set_acl_only_on_changed_objets"
 echo_details "* aws_region: $aws_region"
+echo_details "* show_only_error: $show_only_error"
 echo
 
 validate_required_input "access_key_id" $access_key_id
@@ -135,13 +136,18 @@ if [[ "$aws_region" != "" ]] ; then
 	export AWS_DEFAULT_REGION="${aws_region}"
 fi
 
+show_only_error_flag=""
+if [[ $show_only_error == true ]]; then
+  show_only_error_flag="--only-show-errors"
+fi 
+
 s3_url="s3://${upload_bucket}"
 export AWS_ACCESS_KEY_ID="${access_key_id}"
 export AWS_SECRET_ACCESS_KEY="${secret_access_key}"
 
 # do a sync -> delete no longer existing objects
-echo_info "$ aws s3 sync ${expanded_upload_local_path} ${s3_url} --delete --acl ${aclcmd}"
-aws s3 sync "${expanded_upload_local_path}" "${s3_url}" --delete --acl ${aclcmd}
+echo_info "$ aws s3 sync ${expanded_upload_local_path} ${s3_url} --delete --acl ${aclcmd} ${show_only_error_flag}"
+aws s3 sync "${expanded_upload_local_path}" "${s3_url}" --delete --acl ${aclcmd} ${show_only_error_flag}
 
 if [[ "${set_acl_only_on_changed_objets}" != "true" ]] ; then
   echo_details "Setting ACL on every object, this can take some time..."

--- a/step.yml
+++ b/step.yml
@@ -88,4 +88,13 @@ inputs:
       description: |
         Here you can specify a different AWS region of the bucket. You can leave
         it empty to use the default config/env setting.
+  - show_only_error: "false"
+    opts:
+      title: "Only show error messages"
+      summary: ""
+      description: |
+        Skip printing progress of file upload, only print error if occured.
+      value_options:
+        - "true"
+        - "false"
 outputs: []


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context
When syncing folders there are a loat of log messages lie `upload: path/to/local/files to s3://path/to/remote/file`. This makes difficult to check build logs when syncing folders with many files.

### Changes
Added show_only_error flag to `aws s3 sync` command to skip upload progress, but print error if any.
